### PR TITLE
Add a method to convert the YoGraphicFieldData into a YoGraphicGroupDefinition to be visualized in SCS2. This also keeps things connected without depending on the scs2 jar.

### DIFF
--- a/scs2-session-logger/src/main/java/us/ihmc/scs2/session/log/LogDataReader.java
+++ b/scs2-session-logger/src/main/java/us/ihmc/scs2/session/log/LogDataReader.java
@@ -457,7 +457,7 @@ public class LogDataReader
 
    public List<YoGraphicGroupDefinition> getLogSCS2YoGraphics()
    {
-      return parser.getSCS2YoGraphics();
+      return RobotDataLogTools.toYoGraphicGroupDefinitions(parser.getSCS2YoGraphics());
    }
 
    public List<JointState> getJointStates()

--- a/scs2-session-logger/src/main/java/us/ihmc/scs2/session/remote/RemoteSession.java
+++ b/scs2-session-logger/src/main/java/us/ihmc/scs2/session/remote/RemoteSession.java
@@ -13,6 +13,7 @@ import us.ihmc.scs2.definition.yoGraphic.YoGraphicDefinition;
 import us.ihmc.scs2.session.Session;
 import us.ihmc.scs2.session.SessionMode;
 import us.ihmc.scs2.session.SessionProperties;
+import us.ihmc.scs2.session.tools.RobotDataLogTools;
 import us.ihmc.scs2.session.tools.RobotModelLoader;
 import us.ihmc.scs2.simulation.robot.Robot;
 
@@ -57,7 +58,7 @@ public class RemoteSession extends Session
 
       rootRegistry.addChild(handshakeParser.getRootRegistry());
       rootRegistry.addChild(debugRegistry.getYoRegistry());
-      yoGraphicDefinitions.addAll(handshakeParser.getSCS2YoGraphics());
+      yoGraphicDefinitions.addAll(RobotDataLogTools.toYoGraphicGroupDefinitions(handshakeParser.getSCS2YoGraphics()));
 
       RobotDefinition robotDefinition = RobotModelLoader.loadModel(handshake.getModelName(),
                                                                    handshake.getModelLoaderClass(),

--- a/scs2-session-logger/src/main/java/us/ihmc/scs2/session/tools/RobotDataLogTools.java
+++ b/scs2-session-logger/src/main/java/us/ihmc/scs2/session/tools/RobotDataLogTools.java
@@ -5,7 +5,13 @@ import logger_msgs.Model;
 import logger_msgs.Variables;
 import us.ihmc.robotDataLogger.handshake.YoVariableHandshakeParser;
 import us.ihmc.robotDataLogger.logger.YoVariableLoggerListener;
+import us.ihmc.robotDataLogger.yoGraphics.YoGraphicFieldData;
+import us.ihmc.robotDataLogger.yoGraphics.YoGraphicFieldsData;
 import us.ihmc.scs2.definition.robot.RobotDefinition;
+import us.ihmc.scs2.definition.yoGraphic.YoGraphicDefinition;
+import us.ihmc.scs2.definition.yoGraphic.YoGraphicDefinition.YoGraphicFieldInfo;
+import us.ihmc.scs2.definition.yoGraphic.YoGraphicDefinition.YoGraphicFieldsSummary;
+import us.ihmc.scs2.definition.yoGraphic.YoGraphicGroupDefinition;
 import us.ihmc.scs2.session.log.LogTimeStampedIndexGenerator;
 import us.ihmc.scs2.session.log.ProgressConsumer;
 
@@ -13,6 +19,8 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RobotDataLogTools
 {
@@ -167,6 +175,25 @@ public class RobotDataLogTools
                                         model.getResourceDirectoriesList().toStringArray(),
                                         modelData,
                                         resourceData);
+   }
+
+   /**
+    * Converts the logger's wire-format YoGraphic field data - opaque to the logger, which knows
+    * nothing about {@link YoGraphicDefinition} - back into scs2's typed definition tree.
+    */
+   public static List<YoGraphicGroupDefinition> toYoGraphicGroupDefinitions(List<YoGraphicFieldsData> yoGraphicFieldsDataList)
+   {
+      List<YoGraphicFieldsSummary> summaries = new ArrayList<>();
+
+      for (YoGraphicFieldsData fieldsData : yoGraphicFieldsDataList)
+      {
+         YoGraphicFieldsSummary summary = new YoGraphicFieldsSummary();
+         for (YoGraphicFieldData field : fieldsData)
+            summary.add(new YoGraphicFieldInfo(field.getFieldName(), field.getFieldValue()));
+         summaries.add(summary);
+      }
+
+      return YoGraphicDefinition.parseTreeYoGraphicFieldsSummary(summaries);
    }
 
    public static void updateLogs(File directory, LogProperties properties, ProgressConsumer progressConsumer)


### PR DESCRIPTION
Look here for all the information: https://github.com/ihmcrobotics/ihmc-robot-data-logger