### PR TITLE
Raise default initial buffer size 8192 -> 65536

### DIFF
--- a/scs2-session/src/main/java/us/ihmc/scs2/session/Session.java
+++ b/scs2-session/src/main/java/us/ihmc/scs2/session/Session.java
@@ -72,7 +72,7 @@ public abstract class Session
     * The default value is loaded from the system property: <tt>"scs2.session.buffer.initialsize"</tt>.
     * </p>
     */
-   public static final int DEFAULT_INITIAL_BUFFER_SIZE = SessionPropertiesHelper.loadIntegerProperty("scs2.session.buffer.initialsize", 8192);
+   public static final int DEFAULT_INITIAL_BUFFER_SIZE = SessionPropertiesHelper.loadIntegerProperty("scs2.session.buffer.initialsize", 65536);
    /**
     * Default period at which {@link YoVariable}s are saved into the buffer.
     * <p>


### PR DESCRIPTION
## Summary
- Raise `Session.DEFAULT_INITIAL_BUFFER_SIZE` from 8192 to 65536 so new sessions keep more history for playback and analysis.
- The value is still overridable via the `scs2.session.buffer.initialsize` system property.

Cherry-picked from jerry-e-pratt/simulation-construction-set-2 (`cdfd7e69`). Tracks skills-home issue https://github.com/persona-ai-inc/scs2-skills-duncan/issues/3.

## Test plan
- [ ] Start a session without `scs2.session.buffer.initialsize` set and confirm the buffer is 65536
- [ ] Set `-Dscs2.session.buffer.initialsize=8192` and confirm the override still wins
- [ ] Confirm a large session still clamps via `ADMISSIBLE_BUFFER_TO_MAX_MEMORY_RATIO` instead of OOM


Made with [Cursor](https://cursor.com)