### PR TITLE
Per-variable colored Y-axes for normalized SCS2 charts

### DIFF
--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/charts/DynamicLineChart.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/charts/DynamicLineChart.java
@@ -15,6 +15,7 @@ import javafx.geometry.Orientation;
 import javafx.geometry.Side;
 import javafx.scene.Group;
 import javafx.scene.chart.FastAxisBase;
+import javafx.scene.shape.Rectangle;
 import us.ihmc.javaFXExtensions.chart.DynamicXYChart;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ChartRenderManager;
 
@@ -41,8 +42,13 @@ public class DynamicLineChart extends DynamicXYChart
    };
 
    private final BooleanProperty markerAutoUpdateProperty = new SimpleBooleanProperty(this, "markerAutoUpdate", true);
+   private final BooleanProperty showYAxisProperty = new SimpleBooleanProperty(this, "showYAxis", false);
    private final ObjectProperty<ChartStyle> chartStyleProperty = new SimpleObjectProperty<>(this, "chartStyle", ChartStyle.RAW);
    private final ObservableList<NumberSeriesLayer> seriesLayers = FXCollections.observableArrayList();
+   private final ObservableList<PerVariableYAxis> perSeriesYAxes = FXCollections.observableArrayList();
+   // Our own plot clip: the parent's clip is private and only updated inside its own layoutChartChildren,
+   // which we override without calling super, so we install and manage this one instead.
+   private final Rectangle plotClip = new Rectangle();
    private final ChangeListener<Object> chartUpdaterListener = (o, oldValue, newValue) -> requestChartLayout();
    private final ObservableList<ChartMarker> markers = FXCollections.observableArrayList();
    private final DynamicChartLegend legend = new DynamicChartLegend();
@@ -87,6 +93,10 @@ public class DynamicLineChart extends DynamicXYChart
       yAxisChangeListener.changed(null, null, yAxis);
 
       chartStyleProperty.addListener(chartUpdaterListener);
+      showYAxisProperty.addListener(chartUpdaterListener);
+
+      plotClip.setSmooth(false);
+      plotContent.setClip(plotClip);
 
       plotContent.getChildren().addAll(seriesGroup, markerGroup);
 
@@ -152,6 +162,12 @@ public class DynamicLineChart extends DynamicXYChart
       legend.getItems().add(layer.getLegendNode());
       // Add the plot under the markers
       seriesGroup.getChildren().add(layer);
+
+      PerVariableYAxis perVariableYAxis = new PerVariableYAxis();
+      perVariableYAxis.applyColorStyle(seriesIndex);
+      perSeriesYAxes.add(perVariableYAxis);
+      getChartChildren().add(perVariableYAxis.getNode());
+
       chartUpdaterListener.changed(null, null, null);
    }
 
@@ -172,8 +188,14 @@ public class DynamicLineChart extends DynamicXYChart
          seriesGroup.getChildren().remove(containingLayer.get());
          legend.getItems().remove(containingLayer.get().getLegendNode());
 
+         PerVariableYAxis removedAxis = perSeriesYAxes.remove(indexOf);
+         getChartChildren().remove(removedAxis.getNode());
+
          for (int i = indexOf; i < seriesLayers.size(); i++)
+         {
             setSeriesDefaultStyleClass(seriesLayers.get(i), i);
+            perSeriesYAxes.get(i).applyColorStyle(i);
+         }
 
          chartUpdaterListener.changed(null, null, null);
       }
@@ -195,6 +217,96 @@ public class DynamicLineChart extends DynamicXYChart
       {
          seriesLayer.scheduleRender();
       }
+   }
+
+   @Override
+   protected void layoutChartChildren(double top, double left, double width, double height)
+   {
+      // This replicates DynamicXYChart.layoutChartChildren (from ihmc-javafx-extensions, whose clip is
+      // private and hence not usable from here) and extends it to reserve stacked space on the left for
+      // the per-variable Y-axes. When no per-variable axis is visible the geometry reduces exactly to the
+      // parent's (perVariableTotalWidth == 0), so RAW/Auto/Manual behaves identically to the parent.
+      updateAxisRange();
+
+      // snap top and left to pixels
+      top = snapPositionY(top);
+      left = snapPositionX(left);
+
+      FastAxisBase xAxis = xAxisProperty().get();
+      FastAxisBase yAxis = yAxisProperty().get();
+
+      // Measure the per-variable axes to stack on the left; only shown when individual-scaling and toggled on.
+      boolean showPerVariableAxes = showYAxisProperty.get() && chartStyleProperty.get() == ChartStyle.NORMALIZED;
+      double perVariableTotalWidth = 0.0;
+      double[] perVariableAxisWidths = new double[perSeriesYAxes.size()];
+      for (int i = 0; i < perSeriesYAxes.size(); i++)
+      {
+         PerVariableYAxis perVariableYAxis = perSeriesYAxes.get(i);
+         boolean visible = showPerVariableAxes && perVariableYAxis.hasRealBounds();
+         perVariableYAxis.setVisible(visible);
+         if (visible)
+         {
+            perVariableAxisWidths[i] = Math.ceil(perVariableYAxis.prefWidth(height));
+            perVariableTotalWidth += perVariableAxisWidths[i];
+         }
+      }
+
+      // try and work out width and height of axises
+      double xAxisWidth = 0;
+      double xAxisHeight = 0; // guess x axis height to start with
+      double yAxisWidth = 0;
+      double yAxisHeight = 0;
+      for (int count = 0; count < 5; count++)
+      {
+         yAxisHeight = Math.max(0, snapSizeY(height - xAxisHeight));
+         yAxisWidth = yAxis.prefWidth(yAxisHeight);
+         xAxisWidth = Math.max(0, snapSizeX(width - yAxisWidth - perVariableTotalWidth));
+         double newXAxisHeight = xAxis.prefHeight(xAxisWidth);
+         if (newXAxisHeight == xAxisHeight)
+            break;
+         xAxisHeight = newXAxisHeight;
+      }
+      // round axis sizes up to whole integers to snap to pixel
+      xAxisWidth = Math.ceil(xAxisWidth);
+      xAxisHeight = Math.ceil(xAxisHeight);
+      yAxisWidth = Math.ceil(yAxisWidth);
+      yAxisHeight = Math.ceil(yAxisHeight);
+
+      // resize axises
+      xAxis.resizeRelocate(left + perVariableTotalWidth + yAxisWidth, top + yAxisHeight, xAxisWidth, xAxisHeight);
+      yAxis.resizeRelocate(left + perVariableTotalWidth + 1, top, yAxisWidth, yAxisHeight);
+      // When the chart is resized, need to specifically call out the axises
+      // to lay out as they are unmanaged.
+      xAxis.requestAxisLayout();
+      xAxis.layout();
+      yAxis.requestAxisLayout();
+      yAxis.layout();
+
+      // Stack the per-variable axes to the left of the primary Y-axis: series 0 innermost, series N outermost.
+      double axisCursor = left + perVariableTotalWidth;
+      for (int i = 0; i < perSeriesYAxes.size(); i++)
+      {
+         PerVariableYAxis perVariableYAxis = perSeriesYAxes.get(i);
+         if (!perVariableYAxis.isVisible())
+            continue;
+         double axisWidth = perVariableAxisWidths[i];
+         axisCursor -= axisWidth;
+         perVariableYAxis.resizeRelocate(axisCursor, top, axisWidth, yAxisHeight);
+         perVariableYAxis.requestAxisLayout();
+         perVariableYAxis.layout();
+      }
+
+      // layout plot content
+      layoutPlotChildren(top, left, xAxisWidth, yAxisHeight);
+      // update clip
+      plotClip.setX(left);
+      plotClip.setY(top);
+      plotClip.setWidth(xAxisWidth + 1);
+      plotClip.setHeight(yAxisHeight + 1);
+      // position plot group, its origin is the bottom left corner of the plot area
+      plotContent.setLayoutX(left + perVariableTotalWidth + yAxisWidth);
+      plotContent.setLayoutY(top);
+      plotContent.requestLayout(); // Note: not sure this is right, maybe plotContent should be resizeable
    }
 
    @Override
@@ -223,6 +335,13 @@ public class DynamicLineChart extends DynamicXYChart
    {
       updateXAxisRange();
       updateYAxisRange();
+      updatePerVariableYAxisRanges();
+   }
+
+   private void updatePerVariableYAxisRanges()
+   {
+      for (int i = 0; i < seriesLayers.size(); i++)
+         perSeriesYAxes.get(i).setRealBounds(computeRealYBounds(seriesLayers.get(i).getNumberSeries()));
    }
 
    protected void updateXAxisRange()
@@ -269,17 +388,10 @@ public class DynamicLineChart extends DynamicXYChart
          {
             for (NumberSeriesLayer layer : seriesLayers)
             {
-               NumberSeries series = layer.getNumberSeries();
-
-               ChartDoubleBounds dataYBounds = series.yBoundsProperty().getValue();
+               ChartDoubleBounds dataYBounds = computeRealYBounds(layer.getNumberSeries());
 
                if (dataYBounds == null)
                   continue;
-
-               if (series.getCustomYBounds() != null)
-                  dataYBounds = series.getCustomYBounds();
-               if (series.isNegated())
-                  dataYBounds = dataYBounds.negate();
 
                if (yBounds == null)
                   yBounds = dataYBounds;
@@ -309,6 +421,11 @@ public class DynamicLineChart extends DynamicXYChart
       return markerAutoUpdateProperty;
    }
 
+   public BooleanProperty showYAxisProperty()
+   {
+      return showYAxisProperty;
+   }
+
    public void setChartStyle(ChartStyle style)
    {
       chartStyleProperty.set(style);
@@ -322,6 +439,21 @@ public class DynamicLineChart extends DynamicXYChart
    public ObjectProperty<ChartStyle> chartStyleProperty()
    {
       return chartStyleProperty;
+   }
+
+   static ChartDoubleBounds computeRealYBounds(NumberSeries series)
+   {
+      ChartDoubleBounds dataYBounds = series.yBoundsProperty().getValue();
+
+      if (dataYBounds == null)
+         return null;
+
+      if (series.getCustomYBounds() != null)
+         dataYBounds = series.getCustomYBounds();
+      if (series.isNegated())
+         dataYBounds = dataYBounds.negate();
+
+      return dataYBounds;
    }
 
    private static void setSeriesDefaultStyleClass(NumberSeriesLayer seriesLayer, int seriesIndex)

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/charts/PerVariableYAxis.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/charts/PerVariableYAxis.java
@@ -1,0 +1,90 @@
+package us.ihmc.scs2.sessionVisualizer.jfx.charts;
+
+import javafx.geometry.Side;
+import javafx.scene.chart.NumberAxis;
+
+/**
+ * A per-variable Y-axis shown on the left of a {@link DynamicLineChart} in individual-scaling
+ * (NORMALIZED) mode. Each visible variable gets one, colored to match its series' line and showing
+ * that variable's real min/max range. It wraps a {@link NumberAxis} (which is final and cannot be
+ * subclassed) and is positioned manually by the chart, hence its node is unmanaged.
+ */
+public class PerVariableYAxis
+{
+   private static final int TICK_COUNT = 5;
+
+   private final NumberAxis axis = new NumberAxis();
+   private boolean hasRealBounds = false;
+
+   public PerVariableYAxis()
+   {
+      axis.setSide(Side.LEFT);
+      axis.setAutoRanging(false);
+      axis.setAnimated(false);
+      axis.setMinorTickVisible(false);
+      axis.setManaged(false);
+      axis.getStyleClass().setAll("axis", "per-variable-axis");
+   }
+
+   public NumberAxis getNode()
+   {
+      return axis;
+   }
+
+   public void applyColorStyle(int seriesIndex)
+   {
+      axis.getStyleClass().setAll("axis", "per-variable-axis", DynamicLineChart.getDefaultColorStyle(seriesIndex));
+   }
+
+   public void setRealBounds(ChartDoubleBounds bounds)
+   {
+      if (bounds == null)
+      {
+         hasRealBounds = false;
+         return;
+      }
+
+      hasRealBounds = true;
+      double lower = bounds.getLower();
+      double upper = bounds.getUpper();
+      axis.setLowerBound(lower);
+      axis.setUpperBound(upper);
+      double range = upper - lower;
+      axis.setTickUnit(range > 0.0 ? range / TICK_COUNT : 1.0);
+   }
+
+   public boolean hasRealBounds()
+   {
+      return hasRealBounds;
+   }
+
+   public void setVisible(boolean visible)
+   {
+      axis.setVisible(visible);
+   }
+
+   public boolean isVisible()
+   {
+      return axis.isVisible();
+   }
+
+   public double prefWidth(double height)
+   {
+      return axis.prefWidth(height);
+   }
+
+   public void resizeRelocate(double x, double y, double width, double height)
+   {
+      axis.resizeRelocate(x, y, width, height);
+   }
+
+   public void requestAxisLayout()
+   {
+      axis.requestAxisLayout();
+   }
+
+   public void layout()
+   {
+      axis.layout();
+   }
+}

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/chart/YoChartPanelController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/chart/YoChartPanelController.java
@@ -158,14 +158,9 @@ public class YoChartPanelController extends ObservedAnimationTimer implements Vi
       dynamicLineChart.addMarker(outPointMarker);
       dynamicLineChart.addMarker(bufferIndexMarker);
 
+      dynamicLineChart.showYAxisProperty().bind(showYAxisProperty);
       showYAxisProperty.set(!(dynamicLineChart.getYAxis() instanceof FastNumberAxis));
-      showYAxisProperty.addListener((observable, oldValue, newValue) ->
-                                    {
-                                       if (newValue)
-                                          dynamicLineChart.setYAxis(FastAxisBase.wrap(new NumberAxis()));
-                                       else
-                                          dynamicLineChart.setYAxis(new FastNumberAxis());
-                                    });
+      showYAxisProperty.addListener((observable, oldValue, newValue) -> updatePrimaryYAxis());
 
       userMarkers.addListener((ListChangeListener<ChartMarker>) change ->
       {
@@ -225,6 +220,7 @@ public class YoChartPanelController extends ObservedAnimationTimer implements Vi
          {
             dynamicLineChart.removeMarker(originMarker);
          }
+         updatePrimaryYAxis();
       };
       dynamicLineChart.chartStyleProperty().addListener(originMarkerUpdater);
       originMarkerUpdater.changed(null, null, dynamicLineChart.chartStyleProperty().get());
@@ -284,6 +280,24 @@ public class YoChartPanelController extends ObservedAnimationTimer implements Vi
          }
       };
       dynamicLineChart.borderProperty().addListener(borderInitializer);
+   }
+
+   /**
+    * The primary shared Y-axis only shows the union range in RAW (master-scaling) mode; in NORMALIZED
+    * mode its {@code [0, 1]} range is meaningless and the per-variable axes carry the display instead, so
+    * we keep the hidden {@link FastNumberAxis} there.
+    */
+   private void updatePrimaryYAxis()
+   {
+      boolean showUnionAxis = showYAxisProperty.get() && dynamicLineChart.getChartStyle() == ChartStyle.RAW;
+      boolean unionAxisShown = !(dynamicLineChart.getYAxis() instanceof FastNumberAxis);
+      if (showUnionAxis == unionAxisShown)
+         return;
+
+      if (showUnionAxis)
+         dynamicLineChart.setYAxis(FastAxisBase.wrap(new NumberAxis()));
+      else
+         dynamicLineChart.setYAxis(new FastNumberAxis());
    }
 
    public void setChartConfiguration(YoChartConfigurationDefinition definition)

--- a/scs2-session-visualizer-jfx/src/main/resources/css/GeneralStylesheet.css
+++ b/scs2-session-visualizer-jfx/src/main/resources/css/GeneralStylesheet.css
@@ -387,6 +387,92 @@
     -fx-stroke: CHART_COLOR_10;
 }
 
+/* Per-variable Y-axes (individual-scaling charts): each axis is colored to match its series' line,
+ * reusing the same default-colorN -> CHART_COLOR_(N+1) palette as .chart-series-line above. */
+.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_1;
+}
+
+.default-color0.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_1;
+}
+.default-color0.per-variable-axis .axis-tick-mark,
+.default-color0.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_1;
+}
+
+.default-color1.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_2;
+}
+.default-color1.per-variable-axis .axis-tick-mark,
+.default-color1.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_2;
+}
+
+.default-color2.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_3;
+}
+.default-color2.per-variable-axis .axis-tick-mark,
+.default-color2.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_3;
+}
+
+.default-color3.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_4;
+}
+.default-color3.per-variable-axis .axis-tick-mark,
+.default-color3.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_4;
+}
+
+.default-color4.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_5;
+}
+.default-color4.per-variable-axis .axis-tick-mark,
+.default-color4.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_5;
+}
+
+.default-color5.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_6;
+}
+.default-color5.per-variable-axis .axis-tick-mark,
+.default-color5.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_6;
+}
+
+.default-color6.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_7;
+}
+.default-color6.per-variable-axis .axis-tick-mark,
+.default-color6.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_7;
+}
+
+.default-color7.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_8;
+}
+.default-color7.per-variable-axis .axis-tick-mark,
+.default-color7.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_8;
+}
+
+.default-color8.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_9;
+}
+.default-color8.per-variable-axis .axis-tick-mark,
+.default-color8.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_9;
+}
+
+.default-color9.per-variable-axis {
+    -fx-tick-label-fill: CHART_COLOR_10;
+}
+.default-color9.per-variable-axis .axis-tick-mark,
+.default-color9.per-variable-axis .axis-minor-tick-mark {
+    -fx-stroke: CHART_COLOR_10;
+}
+
 .chart-legend {
     -fx-hgap: 8.0;
     -fx-vgap: 3.0;

--- a/scs2-session-visualizer-jfx/src/test/java/us/ihmc/scs2/sessionVisualizer/jfx/charts/PerVariableYAxisTest.java
+++ b/scs2-session-visualizer-jfx/src/test/java/us/ihmc/scs2/sessionVisualizer/jfx/charts/PerVariableYAxisTest.java
@@ -1,0 +1,355 @@
+package us.ihmc.scs2.sessionVisualizer.jfx.charts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javafx.application.Platform;
+import javafx.geometry.Side;
+import javafx.scene.chart.NumberAxis;
+
+/**
+ * Tests for feature 2202 (per-variable colored Y-axes for normalized charts).
+ *
+ * <p>Two families of tests live here:
+ * <ul>
+ *    <li>Pure logic ({@link DynamicLineChart#computeRealYBounds(NumberSeries)} and
+ *        {@link DynamicLineChart#getDefaultColorStyle(int)}) — no JavaFX toolkit needed, always run.</li>
+ *    <li>{@link PerVariableYAxis} wrapper behavior — needs a live {@link NumberAxis}, hence a JavaFX
+ *        toolkit. The toolkit is booted headlessly (Monocle) in {@link #initToolkit()}; if it cannot be
+ *        hosted in this environment those tests are skipped (not failed) via {@code assumeTrue}.</li>
+ * </ul>
+ */
+public class PerVariableYAxisTest
+{
+   /** Tolerance for double axis-bound comparisons; the values are exact so this only guards FP formatting. */
+   private static final double EPSILON = 1.0e-12;
+
+   private static volatile boolean fxReady = false;
+
+   @BeforeAll
+   static void initToolkit()
+   {
+      try
+      {
+         // These must be set before the toolkit initializes. Harmless if it is already up.
+         System.setProperty("glass.platform", "Monocle");
+         System.setProperty("monocle.platform", "Headless");
+         System.setProperty("prism.order", "sw");
+         System.setProperty("java.awt.headless", "true");
+
+         CountDownLatch latch = new CountDownLatch(1);
+         Platform.startup(latch::countDown);
+         if (!latch.await(15, TimeUnit.SECONDS))
+            throw new IllegalStateException("Timed out waiting for the JavaFX toolkit to start.");
+         fxReady = true;
+      }
+      catch (IllegalStateException alreadyStarted)
+      {
+         // Platform.startup throws if the toolkit is already running (e.g. another test started it).
+         fxReady = true;
+      }
+      catch (Throwable t)
+      {
+         fxReady = false;
+         System.err.println("[PerVariableYAxisTest] JavaFX toolkit unavailable; skipping node-level tests: " + t);
+      }
+   }
+
+   // ------------------------------------------------------------------------------------------------
+   // DynamicLineChart.computeRealYBounds(NumberSeries) — the unit-test seam shared by the RAW union
+   // loop and the per-variable path. Pure; no JavaFX toolkit required.
+   // ------------------------------------------------------------------------------------------------
+
+   @Test
+   public void testComputeRealYBounds_plainDataBounds()
+   {
+      NumberSeries series = new NumberSeries("plain");
+      series.yBoundsProperty().setValue(new ChartDoubleBounds(-3.0, 5.0));
+
+      ChartDoubleBounds result = DynamicLineChart.computeRealYBounds(series);
+
+      assertNotNull(result);
+      assertEquals(-3.0, result.getLower(), EPSILON);
+      assertEquals(5.0, result.getUpper(), EPSILON);
+   }
+
+   @Test
+   public void testComputeRealYBounds_customOverrideWinsOverData()
+   {
+      NumberSeries series = new NumberSeries("custom");
+      series.yBoundsProperty().setValue(new ChartDoubleBounds(-3.0, 5.0));
+      // A deliberately different custom range: if the data bounds leaked through, these literals catch it.
+      series.setCustomYBounds(new ChartDoubleBounds(10.0, 20.0));
+
+      ChartDoubleBounds result = DynamicLineChart.computeRealYBounds(series);
+
+      assertNotNull(result);
+      assertEquals(10.0, result.getLower(), EPSILON);
+      assertEquals(20.0, result.getUpper(), EPSILON);
+   }
+
+   @Test
+   public void testComputeRealYBounds_negatedFlipsAndSwaps()
+   {
+      NumberSeries series = new NumberSeries("negated");
+      series.yBoundsProperty().setValue(new ChartDoubleBounds(-3.0, 5.0));
+      series.setNegated(true);
+
+      ChartDoubleBounds result = DynamicLineChart.computeRealYBounds(series);
+
+      // negate() maps [lower, upper] -> [-upper, -lower]. Expected re-derived independently, not via negate().
+      assertNotNull(result);
+      assertEquals(-5.0, result.getLower(), EPSILON);
+      assertEquals(3.0, result.getUpper(), EPSILON);
+   }
+
+   @Test
+   public void testComputeRealYBounds_customThenNegatedComposeInOrder()
+   {
+      NumberSeries series = new NumberSeries("customNegated");
+      series.yBoundsProperty().setValue(new ChartDoubleBounds(-3.0, 5.0));
+      series.setCustomYBounds(new ChartDoubleBounds(2.0, 6.0));
+      series.setNegated(true);
+
+      ChartDoubleBounds result = DynamicLineChart.computeRealYBounds(series);
+
+      // Custom [2, 6] must win over data, THEN be negated -> [-6, -2]. Guards the override-before-negate order.
+      assertNotNull(result);
+      assertEquals(-6.0, result.getLower(), EPSILON);
+      assertEquals(-2.0, result.getUpper(), EPSILON);
+   }
+
+   @Test
+   public void testComputeRealYBounds_nullDataBoundsGivesNullEvenWithCustom()
+   {
+      NumberSeries series = new NumberSeries("nullData");
+      // Data bounds unset (null) but a custom override IS present: the null-data guard must run FIRST.
+      series.setCustomYBounds(new ChartDoubleBounds(1.0, 2.0));
+      series.yBoundsProperty().setValue(null);
+
+      assertNull(DynamicLineChart.computeRealYBounds(series),
+                 "null data bounds must short-circuit to null before the custom override is consulted");
+   }
+
+   @Test
+   public void testComputeRealYBounds_nullDataBoundsGivesNullEvenWhenNegated()
+   {
+      NumberSeries series = new NumberSeries("nullDataNegated");
+      series.setNegated(true);
+      series.yBoundsProperty().setValue(null);
+
+      assertNull(DynamicLineChart.computeRealYBounds(series));
+   }
+
+   // ------------------------------------------------------------------------------------------------
+   // DynamicLineChart.getDefaultColorStyle(int) — palette index wraps at 8. Expected strings are
+   // hard-coded literals (NOT re-derived with the same "% 8" formula) so the test is independent.
+   // ------------------------------------------------------------------------------------------------
+
+   @Test
+   public void testGetDefaultColorStyle_wrapsAtEight()
+   {
+      assertEquals("default-color0", DynamicLineChart.getDefaultColorStyle(0));
+      assertEquals("default-color1", DynamicLineChart.getDefaultColorStyle(1));
+      assertEquals("default-color7", DynamicLineChart.getDefaultColorStyle(7));
+      assertEquals("default-color0", DynamicLineChart.getDefaultColorStyle(8));
+      assertEquals("default-color1", DynamicLineChart.getDefaultColorStyle(9));
+      assertEquals("default-color7", DynamicLineChart.getDefaultColorStyle(15));
+      assertEquals("default-color0", DynamicLineChart.getDefaultColorStyle(16));
+      assertEquals("default-color4", DynamicLineChart.getDefaultColorStyle(100));
+   }
+
+   // ------------------------------------------------------------------------------------------------
+   // PerVariableYAxis — wrapper over a live NumberAxis. Needs the JavaFX toolkit.
+   // ------------------------------------------------------------------------------------------------
+
+   @Test
+   public void testPerVariableYAxis_constructorConfiguresNode() throws Exception
+   {
+      assumeTrue(fxReady, "JavaFX toolkit not available in this environment");
+
+      runOnFxAndWait(() ->
+      {
+         PerVariableYAxis axis = new PerVariableYAxis();
+         NumberAxis node = axis.getNode();
+
+         assertNotNull(node);
+         assertEquals(Side.LEFT, node.getSide());
+         assertFalse(node.isAutoRanging(), "per-variable axes set explicit real bounds, not autoranged");
+         assertFalse(node.isMinorTickVisible());
+         assertFalse(node.isManaged(), "the axis is positioned manually by the chart, so it must be unmanaged");
+         assertTrue(node.getStyleClass().contains("axis"));
+         assertTrue(node.getStyleClass().contains("per-variable-axis"));
+         assertFalse(axis.hasRealBounds(), "a fresh axis has no real bounds until setRealBounds is called");
+      });
+   }
+
+   @Test
+   public void testPerVariableYAxis_setRealBoundsAppliesToNode() throws Exception
+   {
+      assumeTrue(fxReady, "JavaFX toolkit not available in this environment");
+
+      runOnFxAndWait(() ->
+      {
+         PerVariableYAxis axis = new PerVariableYAxis();
+         axis.setRealBounds(new ChartDoubleBounds(-2.5, 7.0));
+
+         assertTrue(axis.hasRealBounds());
+         NumberAxis node = axis.getNode();
+         assertEquals(-2.5, node.getLowerBound(), EPSILON);
+         assertEquals(7.0, node.getUpperBound(), EPSILON);
+         // tickUnit = (upper - lower) / 5, re-derived here rather than read from the class constant.
+         assertEquals((7.0 - (-2.5)) / 5.0, node.getTickUnit(), EPSILON);
+      });
+   }
+
+   @Test
+   public void testPerVariableYAxis_setRealBoundsNullClearsFlag() throws Exception
+   {
+      assumeTrue(fxReady, "JavaFX toolkit not available in this environment");
+
+      runOnFxAndWait(() ->
+      {
+         PerVariableYAxis axis = new PerVariableYAxis();
+         axis.setRealBounds(new ChartDoubleBounds(1.0, 4.0));
+         assertTrue(axis.hasRealBounds());
+
+         axis.setRealBounds(null);
+         assertFalse(axis.hasRealBounds(), "setRealBounds(null) must mark the axis as having no real bounds");
+      });
+   }
+
+   @Test
+   public void testPerVariableYAxis_zeroRangeUsesFallbackTickUnit() throws Exception
+   {
+      assumeTrue(fxReady, "JavaFX toolkit not available in this environment");
+
+      runOnFxAndWait(() ->
+      {
+         PerVariableYAxis axis = new PerVariableYAxis();
+         // Degenerate range (upper == lower): tick unit must fall back to 1.0, not 0.0 (0 tick unit hangs layout).
+         axis.setRealBounds(new ChartDoubleBounds(3.0, 3.0));
+
+         assertTrue(axis.hasRealBounds());
+         assertEquals(1.0, axis.getNode().getTickUnit(), EPSILON);
+      });
+   }
+
+   @Test
+   public void testPerVariableYAxis_applyColorStylePutsExpectedClassOnNode() throws Exception
+   {
+      assumeTrue(fxReady, "JavaFX toolkit not available in this environment");
+
+      runOnFxAndWait(() ->
+      {
+         PerVariableYAxis axis = new PerVariableYAxis();
+         axis.applyColorStyle(3);
+
+         NumberAxis node = axis.getNode();
+         assertTrue(node.getStyleClass().contains("default-color3"), "index 3 -> default-color3");
+         assertTrue(node.getStyleClass().contains("axis"));
+         assertTrue(node.getStyleClass().contains("per-variable-axis"));
+      });
+   }
+
+   @Test
+   public void testPerVariableYAxis_applyColorStyleWrapsAtEight() throws Exception
+   {
+      assumeTrue(fxReady, "JavaFX toolkit not available in this environment");
+
+      runOnFxAndWait(() ->
+      {
+         PerVariableYAxis axis = new PerVariableYAxis();
+         axis.applyColorStyle(11); // 11 % 8 == 3
+
+         assertTrue(axis.getNode().getStyleClass().contains("default-color3"));
+      });
+   }
+
+   @Test
+   public void testPerVariableYAxis_applyColorStyleReplacesPreviousColor() throws Exception
+   {
+      assumeTrue(fxReady, "JavaFX toolkit not available in this environment");
+
+      runOnFxAndWait(() ->
+      {
+         PerVariableYAxis axis = new PerVariableYAxis();
+         axis.applyColorStyle(1);
+         axis.applyColorStyle(2);
+
+         NumberAxis node = axis.getNode();
+         // Re-coloring (as happens on series removal / re-index) must not leave a stale color class behind.
+         assertTrue(node.getStyleClass().contains("default-color2"));
+         assertFalse(node.getStyleClass().contains("default-color1"),
+                     "the previous color class must be cleared when the axis is recolored");
+         assertTrue(node.getStyleClass().contains("axis"));
+         assertTrue(node.getStyleClass().contains("per-variable-axis"));
+      });
+   }
+
+   @Test
+   public void testPerVariableYAxis_getNodeIsStable() throws Exception
+   {
+      assumeTrue(fxReady, "JavaFX toolkit not available in this environment");
+
+      runOnFxAndWait(() ->
+      {
+         PerVariableYAxis axis = new PerVariableYAxis();
+         assertSame(axis.getNode(), axis.getNode(), "getNode must return the same NumberAxis instance each call");
+      });
+   }
+
+   // ------------------------------------------------------------------------------------------------
+
+   /**
+    * Runs {@code action} on the JavaFX application thread and blocks until it completes, re-throwing any
+    * {@link AssertionError} or exception so the test fails on the calling thread.
+    */
+   private static void runOnFxAndWait(Runnable action) throws Exception
+   {
+      if (Platform.isFxApplicationThread())
+      {
+         action.run();
+         return;
+      }
+
+      CountDownLatch done = new CountDownLatch(1);
+      AtomicReference<Throwable> thrown = new AtomicReference<>();
+      Platform.runLater(() ->
+      {
+         try
+         {
+            action.run();
+         }
+         catch (Throwable t)
+         {
+            thrown.set(t);
+         }
+         finally
+         {
+            done.countDown();
+         }
+      });
+
+      if (!done.await(15, TimeUnit.SECONDS))
+         throw new AssertionError("Timed out waiting for the JavaFX action to complete.");
+
+      Throwable t = thrown.get();
+      if (t instanceof AssertionError)
+         throw (AssertionError) t;
+      if (t != null)
+         throw new RuntimeException(t);
+   }
+}


### PR DESCRIPTION
## Summary
- In NORMALIZED (individual-scaling) chart mode with Show y-axis on, draw one colored Y-axis per series showing that variable's real min/max.
- Hide the shared primary Y-axis in NORMALIZED mode, since its `[0, 1]` range is not useful there.
- Adds `PerVariableYAxis` plus CSS color classes, and `PerVariableYAxisTest` (pure bounds/color logic plus headless JavaFX wrapper tests).

Cherry-picked from jerry-e-pratt/simulation-construction-set-2 (`f26f8b80`). Tracks skills-home issue https://github.com/persona-ai-inc/scs2-skills-duncan/issues/4.

## Test plan
- [x] Open a chart with multiple variables in NORMALIZED mode and enable Show y-axis
- [x] Confirm each series gets a left-side axis colored to match its line, with real min/max
- [x] Toggle Show y-axis off and confirm the per-variable axes disappear
- [x] Switch to RAW (master-scaling) mode and confirm the shared union Y-axis is what shows
- [x] CI: `PerVariableYAxisTest` (logic tests always; JavaFX node tests in the javafx-headless job)

<img width="604" height="215" alt="image" src="https://github.com/user-attachments/assets/e0232ef4-92dc-4097-b1fa-adf97447f4f5" />


Made with [Cursor](https://cursor.com)