### PR TITLE
Show and bind session controls when a log starts from CLI or drop

### DIFF
--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/MultiSessionManager.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/MultiSessionManager.java
@@ -202,7 +202,30 @@ public class MultiSessionManager
       {
          toolkit.startSession(session, callback);
          mainWindowController.startSession();
+         showAndBindMatchingSessionControls(session);
       });
+   }
+
+   /**
+    * After a Log session or MCAP log session is started (CLI {@code -l} or a 3D-view drop), show and
+    * raise the matching controls window and bind it to the running session. Remote sessions are left
+    * alone. Same-type already-open windows are raised rather than duplicated.
+    */
+   private void showAndBindMatchingSessionControls(Session session)
+   {
+      Class<? extends SessionControlsController> controllerType = controllerTypeForSession(session);
+      if (controllerType != LogSessionManagerController.class && controllerType != MCAPLogSessionManagerController.class)
+         return;
+
+      URL fxml = controllerType == LogSessionManagerController.class ?
+            SessionVisualizerIOTools.LOG_SESSION_MANAGER_PANE_FXML_URL :
+            SessionVisualizerIOTools.MCAP_LOG_SESSION_MANAGER_PANE_FXML_URL;
+
+      openSessionControls(toolkit.getMainWindow(), controllerType, fxml);
+
+      SessionControlsController controller = activeController.get();
+      if (controller != null)
+         controller.bindRunningSession(session);
    }
 
    public void stopSession(boolean saveConfiguration, boolean shutdownSession)

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/session/SessionControlsController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/session/SessionControlsController.java
@@ -2,12 +2,22 @@ package us.ihmc.scs2.sessionVisualizer.jfx.session;
 
 import javafx.stage.Stage;
 import javafx.stage.Window;
+import us.ihmc.scs2.session.Session;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.SessionVisualizerToolkit;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 
 public interface SessionControlsController
 {
    void initialize(SessionVisualizerToolkit toolkit);
+
+   /**
+    * Bind these controls to a session that is already running in the toolkit (CLI {@code -l}, or a
+    * drop that started the session without opening this window). No-op when this controller does not
+    * handle that session type, or when it is already bound to the same instance.
+    */
+   default void bindRunningSession(Session session)
+   {
+   }
 
    void notifySessionLoaded();
 

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/session/log/LogSessionManagerController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/session/log/LogSessionManagerController.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import us.ihmc.commons.lists.PairList;
 import us.ihmc.log.LogTools;
 import us.ihmc.messager.javafx.JavaFXMessager;
+import us.ihmc.scs2.session.Session;
 import us.ihmc.scs2.session.log.ChildLogData;
 import us.ihmc.scs2.session.log.ChildLogSynchronization;
 import us.ihmc.scs2.session.log.LogDataReader;
@@ -154,7 +155,8 @@ public class LogSessionManagerController implements SessionControlsController
          }
          else
          {
-            messager.submitMessage(topics.getStartNewSessionRequest(), newValue);
+            if (toolkit.getSession() != newValue)
+               messager.submitMessage(topics.getStartNewSessionRequest(), newValue);
 
             // Remove these controls that were added during the last session
             addedLogCropperProperty.get().clear();
@@ -833,6 +835,16 @@ public class LogSessionManagerController implements SessionControlsController
    {
       enableVariableFilterToggleButton.setSelected(false);
       variableFilterControllerProperty.set(null);
+   }
+
+   @Override
+   public void bindRunningSession(Session session)
+   {
+      if (!(session instanceof LogSession logSession))
+         return;
+      if (activeSessionProperty.get() == logSession)
+         return;
+      activeSessionProperty.set(logSession);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/session/mcap/MCAPLogSessionManagerController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/session/mcap/MCAPLogSessionManagerController.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import us.ihmc.log.LogTools;
 import us.ihmc.messager.TopicListener;
 import us.ihmc.messager.javafx.JavaFXMessager;
+import us.ihmc.scs2.session.Session;
 import us.ihmc.scs2.session.SessionRobotDefinitionListChange;
 import us.ihmc.scs2.session.mcap.MCAPLogCropper;
 import us.ihmc.scs2.session.mcap.MCAPLogCropper.OutputFormat;
@@ -103,6 +104,7 @@ public class MCAPLogSessionManagerController implements SessionControlsControlle
    @FXML
    private MCAPConsoleLogOutputPaneController consoleOutputPaneController;
    private Stage stage;
+   private SessionVisualizerToolkit toolkit;
    private SessionVisualizerTopics topics;
    private JavaFXMessager messager;
    private BackgroundExecutorManager backgroundExecutorManager;
@@ -112,6 +114,7 @@ public class MCAPLogSessionManagerController implements SessionControlsControlle
    @Override
    public void initialize(SessionVisualizerToolkit toolkit)
    {
+      this.toolkit = toolkit;
       stage = new Stage();
 
       topics = toolkit.getTopics();
@@ -167,7 +170,8 @@ public class MCAPLogSessionManagerController implements SessionControlsControlle
          }
          else
          {
-            messager.submitMessage(topics.getStartNewSessionRequest(), newValue);
+            if (toolkit.getSession() != newValue)
+               messager.submitMessage(topics.getStartNewSessionRequest(), newValue);
             initializeControls(newValue);
          }
       };
@@ -312,6 +316,7 @@ public class MCAPLogSessionManagerController implements SessionControlsControlle
       sessionNameLabel.setText(session.getSessionName());
       dateLabel.setText(LogSessionManagerController.parseTimestamp(logFile.getName()));
       logPathLabel.setText(logFile.getAbsolutePath());
+      desiredLogDTProperty.set(session.getDesiredLogDT());
       endSessionButton.setDisable(false);
       logPositionSlider.setDisable(false);
       logPositionSlider.setValue(0.0);
@@ -450,6 +455,16 @@ public class MCAPLogSessionManagerController implements SessionControlsControlle
                                                           setIsLoading(false);
                                                        }
                                                     });
+   }
+
+   @Override
+   public void bindRunningSession(Session session)
+   {
+      if (!(session instanceof MCAPLogSession mcapLogSession))
+         return;
+      if (activeSessionProperty.get() == mcapLogSession)
+         return;
+      activeSessionProperty.set(mcapLogSession);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/test/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/MultiSessionManagerTest.java
+++ b/scs2-session-visualizer-jfx/src/test/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/MultiSessionManagerTest.java
@@ -1,0 +1,301 @@
+package us.ihmc.scs2.sessionVisualizer.jfx.managers;
+
+import javafx.application.Platform;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import us.ihmc.scs2.session.Session;
+import us.ihmc.scs2.session.log.LogSession;
+import us.ihmc.scs2.sessionVisualizer.jfx.MainWindowController;
+import us.ihmc.scs2.sessionVisualizer.jfx.Scene3DBuilder;
+import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerIOTools;
+import us.ihmc.scs2.sessionVisualizer.jfx.session.OpenSessionControlsRequest;
+import us.ihmc.scs2.sessionVisualizer.jfx.session.OpenSessionControlsRequest.SessionType;
+import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Session-controls auto-show/bind at {@link MultiSessionManager}: after a Log session or MCAP log
+ * session is started without the user opening the pane (the CLI {@code -l} path), the matching
+ * window is showing and bound.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+public class MultiSessionManagerTest
+{
+   private static volatile boolean fxReady = false;
+   private static SessionVisualizerToolkit toolkit;
+   private static MultiSessionManager multiSessionManager;
+   private static Stage mainWindow;
+
+   @BeforeAll
+   static void startHarness() throws Exception
+   {
+      try
+      {
+         System.setProperty("yo.allowRepeatingSubname", "true");
+         System.setProperty("glass.platform", "Monocle");
+         System.setProperty("monocle.platform", "Headless");
+         System.setProperty("prism.order", "sw");
+         System.setProperty("java.awt.headless", "true");
+         System.setProperty("__GL_SYNC_TO_VBLANK", "0");
+
+         CountDownLatch latch = new CountDownLatch(1);
+         Platform.startup(latch::countDown);
+         if (!latch.await(15, TimeUnit.SECONDS))
+            throw new IllegalStateException("Timed out waiting for the JavaFX toolkit to start.");
+         fxReady = true;
+      }
+      catch (IllegalStateException alreadyStarted)
+      {
+         fxReady = true;
+      }
+      catch (Throwable t)
+      {
+         fxReady = false;
+         System.err.println("[MultiSessionManagerTest] JavaFX toolkit unavailable; skipping: " + t);
+      }
+
+      assumeTrue(fxReady, "JavaFX toolkit unavailable");
+
+      AtomicReference<Exception> failure = new AtomicReference<>();
+      JavaFXMissingTools.runAndWait(MultiSessionManagerTest.class, () ->
+      {
+         try
+         {
+            mainWindow = new Stage();
+            Scene3DBuilder scene3DBuilder = new Scene3DBuilder();
+            scene3DBuilder.addDefaultLighting();
+            toolkit = new SessionVisualizerToolkit(mainWindow, scene3DBuilder.getRoot());
+
+            FXMLLoader loader = new FXMLLoader(SessionVisualizerIOTools.MAIN_WINDOW_URL);
+            Parent mainPane = loader.load();
+            MainWindowController mainWindowController = loader.getController();
+            mainWindowController.initialize(new SessionVisualizerWindowToolkit(mainWindow, toolkit));
+            mainWindow.setScene(new Scene(mainPane));
+            mainWindow.show();
+
+            multiSessionManager = new MultiSessionManager(toolkit, mainWindowController);
+         }
+         catch (Exception e)
+         {
+            failure.set(e);
+         }
+      });
+      if (failure.get() != null)
+         throw failure.get();
+   }
+
+   @BeforeEach
+   void assumeHarness()
+   {
+      assumeTrue(fxReady && multiSessionManager != null, "JavaFX harness unavailable");
+   }
+
+   @AfterEach
+   void stopSession()
+   {
+      if (multiSessionManager == null)
+         return;
+      JavaFXMissingTools.runAndWait(getClass(), () ->
+      {
+         multiSessionManager.stopSession(false, true);
+         closeSessionControlsWindows();
+      });
+   }
+
+   @AfterAll
+   static void tearDownHarness()
+   {
+      if (multiSessionManager == null)
+         return;
+      JavaFXMissingTools.runAndWait(MultiSessionManagerTest.class, () ->
+      {
+         multiSessionManager.stopSession(false, true);
+         multiSessionManager.shutdown();
+         closeSessionControlsWindows();
+         if (mainWindow != null)
+            mainWindow.close();
+      });
+      multiSessionManager = null;
+      toolkit = null;
+      mainWindow = null;
+   }
+
+   @Test
+   public void testStartLogSessionShowsBoundLogSessionControls() throws Exception
+   {
+      File logDirectory = SessionControlsTestLog.createLogDirectory("cli-bind-log");
+      LogSession logSession = new LogSession(logDirectory, null);
+
+      startSessionOnFx(logSession);
+
+      Stage controls = findOpenStage("Log session controls");
+      assertNotNull(controls, "Log session controls should be showing after a CLI-style start");
+      assertTrue(controls.isShowing());
+      assertBound(controls, SessionControlsTestLog.SESSION_NAME, logDirectory);
+   }
+
+   @Test
+   public void testStartSameTypeAgainKeepsOneRefreshedWindow() throws Exception
+   {
+      File firstDirectory = SessionControlsTestLog.createLogDirectory("cli-bind-log-a", "first-log");
+      File secondDirectory = SessionControlsTestLog.createLogDirectory("cli-bind-log-b", "second-log");
+
+      startSessionOnFx(new LogSession(firstDirectory, null));
+      Stage first = findOpenStage("Log session controls");
+      assertNotNull(first);
+      assertBound(first, "first-log", firstDirectory);
+
+      JavaFXMissingTools.runAndWait(getClass(), () -> multiSessionManager.stopSession(false, true));
+      startSessionOnFx(new LogSession(secondDirectory, null));
+
+      Stage second = findOpenStage("Log session controls");
+      assertNotNull(second);
+      assertTrue(second.isShowing());
+      assertEquals(first, second, "Same-type start should refresh the existing window");
+      assertBound(second, "second-log", secondDirectory);
+   }
+
+   @Test
+   public void testEndSessionClearsPaneAndLeavesWindowOpen() throws Exception
+   {
+      File logDirectory = SessionControlsTestLog.createLogDirectory("cli-bind-end");
+      startSessionOnFx(new LogSession(logDirectory, null));
+
+      Stage controls = findOpenStage("Log session controls");
+      assertNotNull(controls);
+      Button endSession = findButton(controls.getScene().getRoot(), "End session");
+      JavaFXMissingTools.runAndWait(getClass(), endSession::fire);
+
+      assertTrue(controls.isShowing(), "End session should leave the window open");
+      assertEquals("N/D", labelBeside(controls.getScene().getRoot(), "Session name:").getText());
+      assertEquals("N/D", labelBeside(controls.getScene().getRoot(), "Date:").getText());
+      assertEquals("N/D", labelBeside(controls.getScene().getRoot(), "Log path:").getText());
+      assertTrue(endSession.isDisabled(), "End session should disable itself after clearing the pane");
+   }
+
+   @Test
+   public void testOpenLogMenuAfterCliStartShowsAlreadyBoundWindow() throws Exception
+   {
+      File logDirectory = SessionControlsTestLog.createLogDirectory("cli-bind-menu");
+      startSessionOnFx(new LogSession(logDirectory, null));
+
+      Stage controls = findOpenStage("Log session controls");
+      assertNotNull(controls);
+
+      JavaFXMissingTools.runAndWait(getClass(),
+                                    () -> toolkit.getMessager()
+                                                 .submitMessage(toolkit.getTopics().getOpenSessionControlsRequest(),
+                                                                new OpenSessionControlsRequest(mainWindow, SessionType.LOG)));
+
+      Stage afterMenu = findOpenStage("Log session controls");
+      assertEquals(controls, afterMenu);
+      assertTrue(afterMenu.isShowing());
+      assertBound(afterMenu, SessionControlsTestLog.SESSION_NAME, logDirectory);
+   }
+
+   private void startSessionOnFx(Session session)
+   {
+      JavaFXMissingTools.runAndWait(getClass(), () -> multiSessionManager.startSession(session, null));
+   }
+
+   private static void closeSessionControlsWindows()
+   {
+      for (Window window : List.copyOf(Window.getWindows()))
+      {
+         if (window instanceof Stage stage)
+         {
+            String title = stage.getTitle();
+            if ("Log session controls".equals(title) || "MCAP Log session controls".equals(title))
+               stage.close();
+         }
+      }
+   }
+
+   private static Stage findOpenStage(String title)
+   {
+      for (Window window : Window.getWindows())
+      {
+         if (window instanceof Stage stage && title.equals(stage.getTitle()) && stage.isShowing())
+            return stage;
+      }
+      return null;
+   }
+
+   private static void assertBound(Stage controls, String sessionName, File logPath)
+   {
+      assertEquals(sessionName, labelBeside(controls.getScene().getRoot(), "Session name:").getText());
+      assertNotEquals("N/D", labelBeside(controls.getScene().getRoot(), "Date:").getText());
+      assertEquals(logPath.getAbsolutePath(), labelBeside(controls.getScene().getRoot(), "Log path:").getText());
+
+      Button endSession = findButton(controls.getScene().getRoot(), "End session");
+      assertNotNull(endSession);
+      assertFalse(endSession.isDisabled(), "End session should be enabled once the window is bound");
+
+      Node slider = findSlider(controls.getScene().getRoot());
+      assertNotNull(slider);
+      assertFalse(slider.isDisabled(), "Scrub slider should be enabled once the window is bound");
+   }
+
+   private static Label labelBeside(Parent root, String caption)
+   {
+      List<Label> labels = new ArrayList<>();
+      collect(root, Label.class, labels);
+      for (int i = 0; i < labels.size() - 1; i++)
+      {
+         if (caption.equals(labels.get(i).getText()))
+            return labels.get(i + 1);
+      }
+      throw new AssertionError("No label beside '" + caption + "'");
+   }
+
+   private static Button findButton(Parent root, String text)
+   {
+      List<Button> buttons = new ArrayList<>();
+      collect(root, Button.class, buttons);
+      return buttons.stream().filter(b -> text.equals(b.getText())).findFirst().orElse(null);
+   }
+
+   private static Node findSlider(Parent root)
+   {
+      List<Node> nodes = new ArrayList<>();
+      collect(root, Node.class, nodes);
+      return nodes.stream().filter(n -> n.getClass().getSimpleName().contains("Slider")).findFirst().orElse(null);
+   }
+
+   private static <T> void collect(Node node, Class<T> type, List<T> out)
+   {
+      if (type.isInstance(node))
+         out.add(type.cast(node));
+      if (node instanceof Parent parent)
+      {
+         for (Node child : parent.getChildrenUnmodifiable())
+            collect(child, type, out);
+      }
+   }
+}

--- a/scs2-session-visualizer-jfx/src/test/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/SessionControlsTestLog.java
+++ b/scs2-session-visualizer-jfx/src/test/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/SessionControlsTestLog.java
@@ -1,0 +1,92 @@
+package us.ihmc.scs2.sessionVisualizer.jfx.managers;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+
+/**
+ * Writes a tiny uncompressed Yo-variable log directory that {@code LogSession} can open.
+ */
+final class SessionControlsTestLog
+{
+   static final String SESSION_NAME = "cli-bind-log";
+   static final String TIMESTAMP = "20260101_120000";
+
+   private SessionControlsTestLog()
+   {
+   }
+
+   static File createLogDirectory(String directoryName) throws IOException
+   {
+      return createLogDirectory(directoryName, SESSION_NAME);
+   }
+
+   static File createLogDirectory(String directoryName, String sessionName) throws IOException
+   {
+      File logDirectory = Files.createTempDirectory(directoryName).toFile();
+      logDirectory.deleteOnExit();
+
+      Files.writeString(new File(logDirectory, "robotData.log").toPath(), """
+            version=4.0
+            name=%s
+            variables.handshakeFileType=IDL_YAML
+            variables.handshake=handshake.yaml
+            variables.data=robotData.data
+            variables.summary=
+            variables.index=
+            variables.timestamped=true
+            variables.compressed=false
+            timestamp=%s
+            video.hasTimebase=true
+            """.formatted(sessionName, TIMESTAMP));
+
+      Files.writeString(new File(logDirectory, "handshake.yaml").toPath(), """
+            us::ihmc::robotDataLogger::Handshake:
+              dt: 0.001
+              registries:
+              - parent: 0
+                name: root
+              - parent: 0
+                name: testReg
+              variables:
+              - name: value
+                description: ''
+                type: DoubleYoVariable
+                registry: 1
+                enumType: 0
+                allowNullValues: false
+                isParameter: false
+                min: 0.0
+                max: 1.0
+                loadStatus: NoParameter
+              joints: []
+              graphicObjects: []
+              artifacts: []
+              scs2YoGraphicDefinitions: []
+              enumTypes: []
+              referenceFrameInformation:
+                frameIndices:
+                - 0
+                frameNames:
+                - World
+              summary:
+                createSummary: false
+                summaryTriggerVariable: ''
+                summarizedVariables: []
+            """);
+
+      // Uncompressed tick is timestamp + one YoVariable, 8 bytes each. LogDataReader reports
+      // (fileSize / tickSize) - 1 entries, so two ticks yield one readable entry.
+      int tickSize = 16;
+      ByteBuffer data = ByteBuffer.allocate(tickSize * 2).order(ByteOrder.BIG_ENDIAN);
+      data.putLong(1_000_000L);
+      data.putLong(Double.doubleToLongBits(1.0));
+      data.putLong(2_000_000L);
+      data.putLong(Double.doubleToLongBits(2.0));
+      Files.write(new File(logDirectory, "robotData.data").toPath(), data.array());
+
+      return logDirectory;
+   }
+}


### PR DESCRIPTION
## Summary
- After a Log session or MCAP log session starts (`-l` or a 3D-view drop), SCS 2 Session Visualizer now shows/raises the matching controls window and binds it (name, date, path, session-dependent controls).
- Binding is idempotent: if the toolkit already has that session, the pane does not send another `StartNewSessionRequest`.
- MCAP bind copies desired DT from the running session so a CLI `-t` is visible. Remote session controls are left alone.

Cherry-picked from jerry-e-pratt/simulation-construction-set-2 (`e64c1de4`, [PR #1](https://github.com/jerry-e-pratt/simulation-construction-set-2/pull/1)). Tracks skills-home issue https://github.com/persona-ai-inc/scs2-skills-duncan/issues/5.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-17-openjdk gradle :scs2-session-visualizer-jfx-test:test --tests us.ihmc.scs2.sessionVisualizer.jfx.managers.MultiSessionManagerTest`
- [ ] `installDist` + `-l` on a log directory: Log session controls appear bound; Session → Open log… shows the same window, not N/D
- [ ] `-l` on a `.mcap`: MCAP log session controls appear bound; `-t` / `-r` populate
- [ ] Drop a log directory / `.log` / `.mcap` on the 3D view: matching window shows and binds
- [ ] Same-type drop refreshes the existing window; type switch closes the previous one
- [ ] End session clears the pane and leaves the window open


Made with [Cursor](https://cursor.com)