### PR TITLE
Honor Don't-ask-again when replacing a session

### DIFF
--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizer.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizer.java
@@ -8,15 +8,9 @@ import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.Alert;
-import javafx.scene.control.Alert.AlertType;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.Label;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
-import javafx.scene.layout.VBox;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.Window;
@@ -214,31 +208,14 @@ public class SessionVisualizer
 
       if (toolkit.hasActiveSession())
       {
-         if (SessionVisualizerIOTools.isSaveConfigurationPromptSkipped())
+         Optional<Boolean> save = SessionVisualizerIOTools.confirmSaveDefaultConfiguration(primaryStage, true);
+         if (save.isEmpty())
          {
-            saveConfiguration = SessionVisualizerIOTools.getSkippedSaveConfigurationAnswer();
+            if (event != null)
+               event.consume();
+            return;
          }
-         else
-         {
-            Alert alert = new Alert(AlertType.CONFIRMATION, null, ButtonType.YES, ButtonType.NO, ButtonType.CANCEL);
-            CheckBox doNotAskAgainCheckBox = new CheckBox("Don't ask again");
-            alert.getDialogPane().setContent(new VBox(10, new Label("Do you want to save the default configuration?"), doNotAskAgainCheckBox));
-            SessionVisualizerIOTools.addSCSIconToDialog(alert);
-            alert.initOwner(primaryStage);
-            JavaFXMissingTools.centerDialogInOwner(alert);
-
-            Optional<ButtonType> result = alert.showAndWait();
-            if (!result.isPresent() || result.get() == ButtonType.CANCEL)
-            {
-               if (event != null)
-                  event.consume();
-               return;
-            }
-
-            saveConfiguration = result.get() == ButtonType.YES;
-            if (doNotAskAgainCheckBox.isSelected())
-               SessionVisualizerIOTools.setSkipSaveConfigurationPrompt(saveConfiguration);
-         }
+         saveConfiguration = save.get();
       }
 
       stopNow(saveConfiguration);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerIOTools.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerIOTools.java
@@ -4,9 +4,12 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Stage;
@@ -676,6 +679,38 @@ public class SessionVisualizerIOTools
    public static void resetSaveConfigurationPrompt()
    {
       Preferences.userNodeForPackage(SessionVisualizerIOTools.class).remove(SKIP_SAVE_CONFIGURATION_PROMPT_ANSWER_KEY);
+   }
+
+   /**
+    * Asks whether to save the default configuration, honoring a persisted "Don't ask again" choice.
+    *
+    * @param owner the dialog owner, or {@code null}
+    * @param includeCancel {@code true} to offer Cancel (close-app). An empty result means cancelled.
+    * @return whether to save, or empty if the user cancelled
+    */
+   public static Optional<Boolean> confirmSaveDefaultConfiguration(Window owner, boolean includeCancel)
+   {
+      if (isSaveConfigurationPromptSkipped())
+         return Optional.of(getSkippedSaveConfigurationAnswer());
+
+      Alert alert = includeCancel ?
+            new Alert(AlertType.CONFIRMATION, null, ButtonType.YES, ButtonType.NO, ButtonType.CANCEL) :
+            new Alert(AlertType.CONFIRMATION, null, ButtonType.YES, ButtonType.NO);
+      CheckBox doNotAskAgainCheckBox = new CheckBox("Don't ask again");
+      alert.getDialogPane().setContent(new VBox(10, new Label("Do you want to save the default configuration?"), doNotAskAgainCheckBox));
+      addSCSIconToDialog(alert);
+      if (owner != null)
+         alert.initOwner(owner);
+      JavaFXMissingTools.centerDialogInOwner(alert);
+
+      Optional<ButtonType> result = alert.showAndWait();
+      if (result.isEmpty() || result.get() == ButtonType.CANCEL)
+         return Optional.empty();
+
+      boolean save = result.get() == ButtonType.YES;
+      if (doNotAskAgainCheckBox.isSelected())
+         setSkipSaveConfigurationPrompt(save);
+      return Optional.of(save);
    }
 
    /**

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/menu/HelpMenuController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/menu/HelpMenuController.java
@@ -42,7 +42,7 @@ public class HelpMenuController implements VisualizerController
    public void resetSaveConfigurationPrompt()
    {
       SessionVisualizerIOTools.resetSaveConfigurationPrompt();
-      Alert alert = new Alert(AlertType.INFORMATION, "The save-configuration prompt will be shown again on next close.", ButtonType.OK);
+      Alert alert = new Alert(AlertType.INFORMATION, "The save-configuration prompt will be shown again when replacing a session or closing.", ButtonType.OK);
       SessionVisualizerIOTools.addSCSIconToDialog(alert);
       alert.showAndWait();
    }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/MultiSessionManager.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/MultiSessionManager.java
@@ -3,9 +3,6 @@ package us.ihmc.scs2.sessionVisualizer.jfx.managers;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.fxml.FXMLLoader;
-import javafx.scene.control.Alert;
-import javafx.scene.control.Alert.AlertType;
-import javafx.scene.control.ButtonType;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
@@ -82,21 +79,13 @@ public class MultiSessionManager
                                    {
                                       if (toolkit.hasActiveSession())
                                       {
-                                         Alert alert = new Alert(AlertType.CONFIRMATION,
-                                                                 "Do you want to save the default configuration?",
-                                                                 ButtonType.YES,
-                                                                 ButtonType.NO);
                                          Stage owner;
                                          if (activeController.get() != null)
                                             owner = activeController.get().getStage();
                                          else
                                             owner = toolkit.getMainWindow();
-                                         alert.initOwner(owner);
-                                         JavaFXMissingTools.centerDialogInOwner(alert);
-
-                                         SessionVisualizerIOTools.addSCSIconToDialog(alert);
-                                         Optional<ButtonType> result = alert.showAndWait();
-                                         stopSession(result.isPresent() && result.get() == ButtonType.YES, true);
+                                         Optional<Boolean> saveConfiguration = SessionVisualizerIOTools.confirmSaveDefaultConfiguration(owner, false);
+                                         stopSession(saveConfiguration.orElse(false), true);
                                          if (oldValue != null)
                                             oldValue.shutdownSession();
                                       }


### PR DESCRIPTION
## Summary
- One shared confirm helper now serves both close-app and session-replace, so Don't ask again is honored when replacing a Log session (or MCAP log session), not only when quitting.
- Session-replace stays Yes/No (no Cancel); dismissing without Yes means don't save and the new session still loads.
- Help → Reset Save-Configuration Prompt now says the prompt returns when replacing a session or closing.

Same change as already merged on Jerry's fork: https://github.com/jerry-e-pratt/simulation-construction-set-2/pull/2

Spec: https://github.com/persona-ai-inc/scs2-skills-duncan/issues/6

The MultiSessionManager headless replacement test from that PR is not included here: that harness is not on this `develop` yet.

## Test plan
- [ ] Load a `robotData.log`, choose Don't ask again (No) on close or replace, then drag a second log: no Confirmation dialog; the new session becomes active.
- [ ] After Don't ask again on session replace, quit SCS 2 Session Visualizer: no prompt; the remembered Yes/No is used.
- [ ] With no skip set, replacing a session shows Confirmation with Don't ask again and Yes/No only (no Cancel).
- [ ] First log (no session active) does not prompt.
- [ ] Help → Reset Save-Configuration Prompt restores the prompt on both replace and close.


Made with [Cursor](https://cursor.com)